### PR TITLE
Added specific logging macros in scan callback to avoid WDT reset

### DIFF
--- a/src/BleSensors/BleSensors.cpp
+++ b/src/BleSensors/BleSensors.cpp
@@ -39,6 +39,7 @@
 // 20250121 Updated for NimBLE-Arduino v2.x
 // 20250725 Fixed potential buffer overflow
 // 20250728 Fixed naming collision with ATC_MiThermometer
+// 20250808 Added specific logging macros in scan callback to avoid WDT reset
 //
 // ToDo:
 // -
@@ -64,7 +65,7 @@ namespace BleSensorsCallbacks
 
     void onDiscovered(const NimBLEAdvertisedDevice *advertisedDevice) override
     {
-      log_v("Discovered Advertised Device: %s", advertisedDevice->toString().c_str());
+      cb_log_v("Discovered Advertised Device: %s", advertisedDevice->toString().c_str());
     }
 
     void onResult(const NimBLEAdvertisedDevice *advertisedDevice) override
@@ -74,7 +75,7 @@ namespace BleSensorsCallbacks
       bool device_found = false;
       JsonDocument doc;
 
-      log_v("Advertised Device Result: %s", advertisedDevice->toString().c_str());
+      cb_log_v("Advertised Device Result: %s", advertisedDevice->toString().c_str());
       JsonObject BLEdata = doc.to<JsonObject>();
       String mac_adress = advertisedDevice->getAddress().toString().c_str();
 
@@ -83,7 +84,7 @@ namespace BleSensorsCallbacks
       {
         if (mac_adress == m_knownBLEAddresses[idx].c_str())
         {
-          log_v("BLE device found at index %d", idx);
+          cb_log_v("BLE device found at index %d", idx);
           device_found = true;
           m_devices_found++;
           break;
@@ -117,10 +118,10 @@ namespace BleSensorsCallbacks
       {
         if (CORE_DEBUG_LEVEL >= ARDUHAL_LOG_LEVEL_DEBUG)
         {
-        const size_t buf_sz = 512;
-        char buf[buf_sz];
-        serializeJson(BLEdata, buf, buf_sz);
-          log_d("TheengsDecoder found device: %s", buf);
+          const size_t buf_sz = 512;
+          char buf[buf_sz];
+          serializeJson(BLEdata, buf, buf_sz);
+          cb_log_d("TheengsDecoder found device: %s", buf);
         }
 
         // see https://stackoverflow.com/questions/5348089/passing-a-vector-between-functions-via-pointers
@@ -129,11 +130,11 @@ namespace BleSensorsCallbacks
         (*m_sensorData)[idx].batt_level = (uint8_t)BLEdata["batt"];
         (*m_sensorData)[idx].rssi = (int)BLEdata["rssi"];
         (*m_sensorData)[idx].valid = ((*m_sensorData)[idx].batt_level > 0);
-        log_i("Temperature:       %.1f°C", (*m_sensorData)[idx].temperature);
-        log_i("Humidity:          %.1f%%", (*m_sensorData)[idx].humidity);
-        log_i("Battery level:     %d%%", (*m_sensorData)[idx].batt_level);
-        log_i("RSSI:             %ddBm", (*m_sensorData)[idx].rssi = (int)BLEdata["rssi"]);
-        log_d("BLE devices found: %d", m_devices_found);
+        cb_log_i("Temperature:       %.1f°C", (*m_sensorData)[idx].temperature);
+        cb_log_i("Humidity:          %.1f%%", (*m_sensorData)[idx].humidity);
+        cb_log_i("Battery level:     %d%%", (*m_sensorData)[idx].batt_level);
+        cb_log_i("RSSI:             %ddBm", (*m_sensorData)[idx].rssi = (int)BLEdata["rssi"]);
+        cb_log_d("BLE devices found: %d", m_devices_found);
 
         BLEdata.remove("manufacturerdata");
         BLEdata.remove("servicedata");
@@ -142,14 +143,14 @@ namespace BleSensorsCallbacks
       // Abort scanning because all known devices have been found
       if (m_devices_found == m_knownBLEAddresses.size())
       {
-        log_i("All devices found.");
+        cb_log_i("All devices found.");
         m_pBLEScan->stop();
       }
     }
 
     void onScanEnd(const NimBLEScanResults &results, int reason) override
     {
-      log_v("Scan Ended; reason = %d", reason);
+      cb_log_v("Scan Ended; reason = %d", reason);
     }
   } scanCallbacks;
 

--- a/src/BleSensors/BleSensors.h
+++ b/src/BleSensors/BleSensors.h
@@ -38,6 +38,7 @@
 // 20240417 Added additional constructor and method setAddresses()
 // 20240427 Added paramter activeScan to getData()
 // 20250121 Updated for NimBLE-Arduino v2.x
+// 20250808 Added specific logging macros in scan callback to avoid WDT reset
 //
 // ToDo:
 // - 
@@ -51,6 +52,26 @@
 #include <Arduino.h>
 #include <NimBLEDevice.h>       //!< https://github.com/h2zero/NimBLE-Arduino
 #include <decoder.h>            //!< https://github.com/theengs/decoder
+
+// Extensive logging in the callback may lead to a watchdog reset
+// see 
+// https://github.com/h2zero/NimBLE-Arduino/issues/329
+// https://github.com/h2zero/NimBLE-Arduino/issues/351
+
+//#define CB_LOGGING
+#if defined(CB_LOGGING)
+#define cb_log_i log_i
+#define cb_log_w log_w
+#define cb_log_d log_d
+#define cb_log_e log_e
+#define cb_log_v log_v
+#else
+#define cb_log_i {}
+#define cb_log_w {}
+#define cb_log_d {}
+#define cb_log_e {}
+#define cb_log_v {}
+#endif
 
 /*!
  * \brief BLE sensor data


### PR DESCRIPTION
Occasionally the task watchdog was triggered during the BLE scan, presumably if the expected device was not found:
```
I NimBLEScan: Duplicate; updated: a0:d7:f3:6a:f1:ab
I NimBLEScan: Duplicate; updated: 4c:c6:1b:17:49:1c
I NimBLEScan: Scan response from: 4c:c6:1b:17:49:1c
I NimBLEAdvertisedDevice: No service data found
I NimBLEScan: Duplicate; updated: 46:db:c6:6c:d6:9d
E (33572) task_wdt: Task watchdog got triggered. The following tasks/users did not reset the watchdog in time:
E (33572) task_wdt:  - IDLE0 (CPU 0)
E (33572) task_wdt: Tasks currently running:
E (33572) task_wdt: CPU 0: nimble_host
E (33572) task_wdt: CPU 1: IDLE1
E (33572) task_wdt: Aborting.
E (33572) task_wdt: Print CPU 0 (current core) backtrace




Backtrace: 0x40083363:0x3ffd0cf0 0x40083499:0x3ffd0d20 0x4008361d:0x3ffd0d40 0x40083649:0x3ffd0d60 0x4009c985:0x3ffd0d80 0x400d56f9:0x3ffd0da0 0x400d5a41:0x3ffd0dc0 0x401015f5:0x3ffd0de0 0x4010146f:0x3ffd0e20 0x401015ad:0x3ffd0e60 0x401015ad:0x3ffd0ea0 0x401015ad:0x3ffd0ee0 0x40101671:0x3ffd0f20 0x401038d5:0x3ffd0fa0 0x400dbcd9:0x3ffd1210 0x400ed0dd:0x3ffd1500 0x400f1d91:0x3ffd1560 0x400f7152:0x3ffd15d0 0x400f6efb:0x3ffd1610 0x400f73e5:0x3ffd1630 0x400f5fa1:0x3ffd1650 0x400fdd91:0x3ffd1670 0x400ec05c:0x3ffd1690 0x400973a5:0x3ffd16b0




ELF file SHA256: 16a97e616

Rebooting...
ets Jun  8 2016 00:22:57
```
Disabling log messages in the scan callback (by using a dedicated macro) seems to help as a workaround.
