### PR TITLE
20250912 fix m5core2

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -24,7 +24,7 @@ jobs:
           #- esp32:esp32:heltec_wifi_lora_32_V2
           - esp32:esp32:heltec_wifi_lora_32_V3
           #- esp32:esp32:featheresp32
-          - esp32:esp32:m5stack_core2
+          #- esp32:esp32:m5stack_core2 # Needs arduino-esp32 v3.0.7
           - esp32:esp32:esp32s3_powerfeather
           - esp32:esp32:adafruit_feather_esp32s2
           - rp2040:rp2040:adafruit_feather:dbgport=Serial


### PR DESCRIPTION
Needs arduino-esp32 v3.0.7, otherwise you'll get a linker error:
```
/home/runner/.arduino15/packages/esp32/tools/esp-x32/2411/bin/../lib/gcc/xtensa-esp-elf/14.2.0/../../../../xtensa-esp-elf/bin/ld: /home/runner/.cache/arduino/sketches/.../BresserWeatherSensorLW.ino.elf section `.iram0.text' will not fit in region `iram0_0_seg'
/home/runner/.arduino15/packages/esp32/tools/esp-x32/2411/bin/../lib/gcc/xtensa-esp-elf/14.2.0/../../../../xtensa-esp-elf/bin/ld: IRAM0 segment data does not fit.
/home/runner/.arduino15/packages/esp32/tools/esp-x32/2411/bin/../lib/gcc/xtensa-esp-elf/14.2.0/../../../../xtensa-esp-elf/bin/ld: region `iram0_0_seg' overflowed by 3492 bytes
collect2: error: ld returned 1 exit status
```